### PR TITLE
Add support for Dynamic IP Allocation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_ip_allocation_method"></a> [ip\_allocation\_method](#input\_ip\_allocation\_method)
+
+Description: The IP address allocation method, must be either 'Static' or 'Dynamic'.
+
+Type: `string`
+
+Default: `"Static"`
+
 ### <a name="input_lock"></a> [lock](#input\_lock)
 
 Description: Controls the Resource Lock configuration for this resource. The following properties can be specified:

--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ Default: `null`
 
 ### <a name="input_ip_allocation_method"></a> [ip\_allocation\_method](#input\_ip\_allocation\_method)
 
-Description: The IP address allocation method, must be either 'Static' or 'Dynamic'.
+Description: The IP address allocation method, must be either 'Static' or 'Dynamic'. Default is dynamic
 
 Type: `string`
 
-Default: `"Static"`
+Default: `"Dynamic"`
 
 ### <a name="input_lock"></a> [lock](#input\_lock)
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -88,7 +88,7 @@ The following input variables are required:
 
 ### <a name="input_custom_location_name"></a> [custom\_location\_name](#input\_custom\_location\_name)
 
-Description: The name of the custom location.
+Description: Enter the custom location name of your HCI cluster.
 
 Type: `string`
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -53,12 +53,14 @@ module "test" {
   resource_group_id  = data.azurerm_resource_group.rg.id
   custom_location_id = data.azapi_resource.customlocation.id
 
-  vm_switch_name   = "ConvergedSwitch(managementcomputestorage)"
-  starting_address = "192.168.200.0"
-  ending_address   = "192.168.200.255"
-  dns_servers      = ["192.168.200.222"]
-  default_gateway  = "192.168.200.1"
-  address_prefix   = "192.168.200.0/24"
+  vm_switch_name = "ConvergedSwitch(managementcomputestorage)"
+
+  ip_allocation_method = "Static"
+  starting_address     = "192.168.200.0"
+  ending_address       = "192.168.200.255"
+  dns_servers          = ["192.168.200.222"]
+  default_gateway      = "192.168.200.1"
+  address_prefix       = "192.168.200.0/24"
 }
 ```
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -47,10 +47,12 @@ module "test" {
   resource_group_id  = data.azurerm_resource_group.rg.id
   custom_location_id = data.azapi_resource.customlocation.id
 
-  vm_switch_name   = "ConvergedSwitch(managementcomputestorage)"
-  starting_address = "192.168.200.0"
-  ending_address   = "192.168.200.255"
-  dns_servers      = ["192.168.200.222"]
-  default_gateway  = "192.168.200.1"
-  address_prefix   = "192.168.200.0/24"
+  vm_switch_name = "ConvergedSwitch(managementcomputestorage)"
+
+  ip_allocation_method = "Static"
+  starting_address     = "192.168.200.0"
+  ending_address       = "192.168.200.255"
+  dns_servers          = ["192.168.200.222"]
+  default_gateway      = "192.168.200.1"
+  address_prefix       = "192.168.200.0/24"
 }

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -1,6 +1,6 @@
 variable "custom_location_name" {
   type        = string
-  description = "The name of the custom location."
+  description = "Enter the custom location name of your HCI cluster."
 }
 
 variable "logical_network_name" {

--- a/examples/dhcp/README.md
+++ b/examples/dhcp/README.md
@@ -54,8 +54,6 @@ module "test" {
   custom_location_id = data.azapi_resource.customlocation.id
   vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
 
-  ip_allocation_method = "Dynamic"
-
   logical_network_tags = {
     environment = "development"
   }

--- a/examples/dhcp/README.md
+++ b/examples/dhcp/README.md
@@ -118,14 +118,6 @@ Type: `bool`
 
 Default: `true`
 
-### <a name="input_ip_allocation_method"></a> [ip\_allocation\_method](#input\_ip\_allocation\_method)
-
-Description: The IP address allocation method, must be either 'Static' or 'Dynamic'.
-
-Type: `string`
-
-Default: `"Static"`
-
 ## Outputs
 
 No outputs.

--- a/examples/dhcp/README.md
+++ b/examples/dhcp/README.md
@@ -1,5 +1,5 @@
 <!-- BEGIN_TF_DOCS -->
-# Default example
+# Dynamic IP Address Allocation example
 
 This deploys the module in its simplest form.
 
@@ -53,13 +53,13 @@ module "test" {
   enable_telemetry   = var.enable_telemetry # see variables.tf
   resource_group_id  = data.azurerm_resource_group.rg.id
   custom_location_id = data.azapi_resource.customlocation.id
+  vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
 
-  vm_switch_name   = "ConvergedSwitch(managementcomputestorage)"
-  starting_address = "192.168.200.0"
-  ending_address   = "192.168.200.255"
-  dns_servers      = ["192.168.200.222"]
-  default_gateway  = "192.168.200.1"
-  address_prefix   = "192.168.200.0/24"
+  ip_allocation_method = "Dynamic"
+
+  logical_network_tags = {
+    environment = "development"
+  }
 }
 ```
 
@@ -117,6 +117,14 @@ If it is set to false, then no telemetry will be collected.
 Type: `bool`
 
 Default: `true`
+
+### <a name="input_ip_allocation_method"></a> [ip\_allocation\_method](#input\_ip\_allocation\_method)
+
+Description: The IP address allocation method, must be either 'Static' or 'Dynamic'.
+
+Type: `string`
+
+Default: `"Static"`
 
 ## Outputs
 

--- a/examples/dhcp/README.md
+++ b/examples/dhcp/README.md
@@ -46,9 +46,8 @@ module "test" {
   # source             = "Azure/avm-res-azurestackhci-logicalnetwork/azurerm"
   # version = "~> 0.1.0"
 
-  location            = data.azurerm_resource_group.rg.location
-  name                = var.logical_network_name
-  resource_group_name = data.azurerm_resource_group.rg.name
+  location = data.azurerm_resource_group.rg.location
+  name     = var.logical_network_name
 
   enable_telemetry   = var.enable_telemetry # see variables.tf
   resource_group_id  = data.azurerm_resource_group.rg.id

--- a/examples/dhcp/_footer.md
+++ b/examples/dhcp/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/dhcp/_header.md
+++ b/examples/dhcp/_header.md
@@ -1,0 +1,3 @@
+# Dynamic IP Address Allocation example
+
+This deploys the module in its simplest form.

--- a/examples/dhcp/main.tf
+++ b/examples/dhcp/main.tf
@@ -40,9 +40,8 @@ module "test" {
   # source             = "Azure/avm-res-azurestackhci-logicalnetwork/azurerm"
   # version = "~> 0.1.0"
 
-  location            = data.azurerm_resource_group.rg.location
-  name                = var.logical_network_name
-  resource_group_name = data.azurerm_resource_group.rg.name
+  location = data.azurerm_resource_group.rg.location
+  name     = var.logical_network_name
 
   enable_telemetry   = var.enable_telemetry # see variables.tf
   resource_group_id  = data.azurerm_resource_group.rg.id

--- a/examples/dhcp/main.tf
+++ b/examples/dhcp/main.tf
@@ -47,11 +47,11 @@ module "test" {
   enable_telemetry   = var.enable_telemetry # see variables.tf
   resource_group_id  = data.azurerm_resource_group.rg.id
   custom_location_id = data.azapi_resource.customlocation.id
+  vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
 
-  vm_switch_name   = "ConvergedSwitch(managementcomputestorage)"
-  starting_address = "192.168.200.0"
-  ending_address   = "192.168.200.255"
-  dns_servers      = ["192.168.200.222"]
-  default_gateway  = "192.168.200.1"
-  address_prefix   = "192.168.200.0/24"
+  ip_allocation_method = "Dynamic"
+
+  logical_network_tags = {
+    environment = "development"
+  }
 }

--- a/examples/dhcp/main.tf
+++ b/examples/dhcp/main.tf
@@ -48,8 +48,6 @@ module "test" {
   custom_location_id = data.azapi_resource.customlocation.id
   vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
 
-  ip_allocation_method = "Dynamic"
-
   logical_network_tags = {
     environment = "development"
   }

--- a/examples/dhcp/variables.tf
+++ b/examples/dhcp/variables.tf
@@ -1,0 +1,35 @@
+variable "custom_location_name" {
+  type        = string
+  description = "The name of the custom location."
+}
+
+variable "logical_network_name" {
+  type        = string
+  description = "The name of the logical network"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The resource group where the resources will be deployed."
+}
+
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "ip_allocation_method" {
+  type        = string
+  default     = "Static"
+  description = "The IP address allocation method, must be either 'Static' or 'Dynamic'."
+
+  validation {
+    condition     = contains(["Static", "Dynamic"], var.ip_allocation_method)
+    error_message = "The ip_allocation_method must be either 'Static' or 'Dynamic'."
+  }
+}

--- a/examples/dhcp/variables.tf
+++ b/examples/dhcp/variables.tf
@@ -22,14 +22,3 @@ For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
-
-variable "ip_allocation_method" {
-  type        = string
-  default     = "Static"
-  description = "The IP address allocation method, must be either 'Static' or 'Dynamic'."
-
-  validation {
-    condition     = contains(["Static", "Dynamic"], var.ip_allocation_method)
-    error_message = "The ip_allocation_method must be either 'Static' or 'Dynamic'."
-  }
-}

--- a/examples/static/README.md
+++ b/examples/static/README.md
@@ -53,13 +53,19 @@ module "test" {
   enable_telemetry   = var.enable_telemetry # see variables.tf
   resource_group_id  = data.azurerm_resource_group.rg.id
   custom_location_id = data.azapi_resource.customlocation.id
+  vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
 
-  vm_switch_name   = "ConvergedSwitch(managementcomputestorage)"
-  starting_address = "192.168.200.0"
-  ending_address   = "192.168.200.255"
-  dns_servers      = ["192.168.200.222"]
-  default_gateway  = "192.168.200.1"
-  address_prefix   = "192.168.200.0/24"
+  ip_allocation_method = var.ip_allocation_method
+  starting_address     = "192.168.200.0"
+  ending_address       = "192.168.200.255"
+  default_gateway      = "192.168.200.1"
+
+  dns_servers    = ["192.168.200.222"]
+  address_prefix = "192.168.200.0/24"
+
+  logical_network_tags = {
+    environment = "development"
+  }
 }
 ```
 
@@ -117,6 +123,14 @@ If it is set to false, then no telemetry will be collected.
 Type: `bool`
 
 Default: `true`
+
+### <a name="input_ip_allocation_method"></a> [ip\_allocation\_method](#input\_ip\_allocation\_method)
+
+Description: The IP address allocation method, must be either 'Static' or 'Dynamic'.
+
+Type: `string`
+
+Default: `"Static"`
 
 ## Outputs
 

--- a/examples/static/README.md
+++ b/examples/static/README.md
@@ -46,9 +46,8 @@ module "test" {
   # source             = "Azure/avm-res-azurestackhci-logicalnetwork/azurerm"
   # version = "~> 0.1.0"
 
-  location            = data.azurerm_resource_group.rg.location
-  name                = var.logical_network_name
-  resource_group_name = data.azurerm_resource_group.rg.name
+  location = data.azurerm_resource_group.rg.location
+  name     = var.logical_network_name
 
   enable_telemetry   = var.enable_telemetry # see variables.tf
   resource_group_id  = data.azurerm_resource_group.rg.id

--- a/examples/static/README.md
+++ b/examples/static/README.md
@@ -55,7 +55,7 @@ module "test" {
   custom_location_id = data.azapi_resource.customlocation.id
   vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
 
-  ip_allocation_method = var.ip_allocation_method
+  ip_allocation_method = "Static"
   starting_address     = "192.168.200.0"
   ending_address       = "192.168.200.255"
   default_gateway      = "192.168.200.1"
@@ -123,14 +123,6 @@ If it is set to false, then no telemetry will be collected.
 Type: `bool`
 
 Default: `true`
-
-### <a name="input_ip_allocation_method"></a> [ip\_allocation\_method](#input\_ip\_allocation\_method)
-
-Description: The IP address allocation method, must be either 'Static' or 'Dynamic'.
-
-Type: `string`
-
-Default: `"Static"`
 
 ## Outputs
 

--- a/examples/static/_footer.md
+++ b/examples/static/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/static/_header.md
+++ b/examples/static/_header.md
@@ -1,0 +1,3 @@
+# Default example
+
+This deploys the module in its simplest form.

--- a/examples/static/main.tf
+++ b/examples/static/main.tf
@@ -40,9 +40,8 @@ module "test" {
   # source             = "Azure/avm-res-azurestackhci-logicalnetwork/azurerm"
   # version = "~> 0.1.0"
 
-  location            = data.azurerm_resource_group.rg.location
-  name                = var.logical_network_name
-  resource_group_name = data.azurerm_resource_group.rg.name
+  location = data.azurerm_resource_group.rg.location
+  name     = var.logical_network_name
 
   enable_telemetry   = var.enable_telemetry # see variables.tf
   resource_group_id  = data.azurerm_resource_group.rg.id

--- a/examples/static/main.tf
+++ b/examples/static/main.tf
@@ -49,7 +49,7 @@ module "test" {
   custom_location_id = data.azapi_resource.customlocation.id
   vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
 
-  ip_allocation_method = var.ip_allocation_method
+  ip_allocation_method = "Static"
   starting_address     = "192.168.200.0"
   ending_address       = "192.168.200.255"
   default_gateway      = "192.168.200.1"

--- a/examples/static/main.tf
+++ b/examples/static/main.tf
@@ -47,11 +47,17 @@ module "test" {
   enable_telemetry   = var.enable_telemetry # see variables.tf
   resource_group_id  = data.azurerm_resource_group.rg.id
   custom_location_id = data.azapi_resource.customlocation.id
+  vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
 
-  vm_switch_name   = "ConvergedSwitch(managementcomputestorage)"
-  starting_address = "192.168.200.0"
-  ending_address   = "192.168.200.255"
-  dns_servers      = ["192.168.200.222"]
-  default_gateway  = "192.168.200.1"
-  address_prefix   = "192.168.200.0/24"
+  ip_allocation_method = var.ip_allocation_method
+  starting_address     = "192.168.200.0"
+  ending_address       = "192.168.200.255"
+  default_gateway      = "192.168.200.1"
+
+  dns_servers    = ["192.168.200.222"]
+  address_prefix = "192.168.200.0/24"
+
+  logical_network_tags = {
+    environment = "development"
+  }
 }

--- a/examples/static/variables.tf
+++ b/examples/static/variables.tf
@@ -1,0 +1,35 @@
+variable "custom_location_name" {
+  type        = string
+  description = "The name of the custom location."
+}
+
+variable "logical_network_name" {
+  type        = string
+  description = "The name of the logical network"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The resource group where the resources will be deployed."
+}
+
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "ip_allocation_method" {
+  type        = string
+  default     = "Static"
+  description = "The IP address allocation method, must be either 'Static' or 'Dynamic'."
+
+  validation {
+    condition     = contains(["Static", "Dynamic"], var.ip_allocation_method)
+    error_message = "The ip_allocation_method must be either 'Static' or 'Dynamic'."
+  }
+}

--- a/examples/static/variables.tf
+++ b/examples/static/variables.tf
@@ -22,14 +22,3 @@ For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
-
-variable "ip_allocation_method" {
-  type        = string
-  default     = "Static"
-  description = "The IP address allocation method, must be either 'Static' or 'Dynamic'."
-
-  validation {
-    condition     = contains(["Static", "Dynamic"], var.ip_allocation_method)
-    error_message = "The ip_allocation_method must be either 'Static' or 'Dynamic'."
-  }
-}

--- a/locals.tf
+++ b/locals.tf
@@ -2,15 +2,15 @@ locals {
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
   subnet_0_properties                = { for k, v in local.subnet_0_properties_full : k => v if v != null }
   subnet_0_properties_full = {
-    addressPrefix      = var.address_prefix, # compute from starting address and ending address
-    ipAllocationMethod = "Static",
-    ipPools = [{
+    addressPrefix      = var.ip_allocation_method == "Dynamic" ? null : var.address_prefix, # compute from starting address and ending address
+    ipAllocationMethod = var.ip_allocation_method,
+    ipPools = var.ip_allocation_method == "Dynamic" ? null : [{
       info  = {}
       start = var.starting_address
       end   = var.ending_address
     }]
     vlan = var.vlan_id == null ? null : tonumber(var.vlan_id)
-    routeTable = {
+    routeTable = var.ip_allocation_method == "Dynamic" ? null : {
       properties = {
         routes = [
           {

--- a/main.tf
+++ b/main.tf
@@ -52,10 +52,5 @@ resource "azapi_resource" "logical_network" {
     ignore_changes = [
       body.properties.subnets[0].properties.ipPools[0].info,
     ]
-
-    precondition {
-      condition     = length(var.starting_address) > 0 && length(var.ending_address) > 0 && length(var.default_gateway) > 0 && length(var.dns_servers) > 0 && length(var.address_prefix) > 0
-      error_message = "When not using existing logical network, starting_address, ending_address, default_gateway, dns_servers, address_prefix are required"
-    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "azapi_resource" "logical_network" {
     }
     properties = {
       dhcpOptions = {
-        dnsServers = flatten(var.dns_servers)
+        dnsServers = var.ip_allocation_method == "Dynamic" ? null : flatten(var.dns_servers)
       }
       subnets = [{
         name       = var.subnet_0_name

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,17 @@ variable "ending_address" {
   description = "The ending IP address of the IP address range."
 }
 
+variable "ip_allocation_method" {
+  type        = string
+  default     = "Static"
+  description = "The IP address allocation method, must be either 'Static' or 'Dynamic'."
+
+  validation {
+    condition     = contains(["Static", "Dynamic"], var.ip_allocation_method)
+    error_message = "The ip_allocation_method must be either 'Static' or 'Dynamic'."
+  }
+}
+
 variable "lock" {
   type = object({
     kind = string

--- a/variables.tf
+++ b/variables.tf
@@ -62,8 +62,8 @@ variable "ending_address" {
 
 variable "ip_allocation_method" {
   type        = string
-  default     = "Static"
-  description = "The IP address allocation method, must be either 'Static' or 'Dynamic'."
+  default     = "Dynamic"
+  description = "The IP address allocation method, must be either 'Static' or 'Dynamic'. Default is dynamic"
 
   validation {
     condition     = contains(["Static", "Dynamic"], var.ip_allocation_method)


### PR DESCRIPTION
## Description

### Problem
Currently, only logical networks of type "Static" can be created. The "Static" type is hardcoded as shown below:

```
  subnet_0_properties_full = {
    addressPrefix      = var.address_prefix, # compute from starting address and ending address
    ipAllocationMethod = "Static",
    ipPools = [{
      info  = {}
      start = var.starting_address
      end   = var.ending_address
    }]
```

### Solution

This PR introduces a way to specify the type of logical network through the following variable:

1. `ip_allocation_method` [Optional] - Specifies whether the IP address allocation should be "Static" or "Dynamic". This variable is optional and defaults to `Dynamic`.

### How to test

Navigate to `examples/dhcp/` and execute the `terraform` commands.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
