### PR TITLE
Add examples of how to provision multiple logical networks through a single template

### DIFF
--- a/examples/multi/README.md
+++ b/examples/multi/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
-# Default example
+# Multiple Logical Network Provisioning example
 
-This deploys the module in its simplest form.
+This deploys multiple logical networks.
 
 ```hcl
 terraform {
@@ -41,18 +41,18 @@ data "azapi_resource" "customlocation" {
 # Do not specify location here due to the randomization above.
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
-module "test" {
+module "call1" {
   source = "../../"
   # source             = "Azure/avm-res-azurestackhci-logicalnetwork/azurerm"
   # version = "~> 0.1.0"
 
   location = data.azurerm_resource_group.rg.location
-  name     = var.logical_network_name
+  name     = "lnetstatic"
 
   enable_telemetry   = var.enable_telemetry # see variables.tf
   resource_group_id  = data.azurerm_resource_group.rg.id
   custom_location_id = data.azapi_resource.customlocation.id
-  vm_switch_name     = "extSwitch"
+  vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
 
   ip_allocation_method = "Static"
   starting_address     = "192.168.200.0"
@@ -65,6 +65,22 @@ module "test" {
   logical_network_tags = {
     environment = "development"
   }
+}
+
+
+module "call2" {
+  source = "../../"
+  # source             = "Azure/avm-res-azurestackhci-logicalnetwork/azurerm"
+  # version = "~> 0.1.0"
+
+  location = data.azurerm_resource_group.rg.location
+  name     = "lnetdynamic"
+
+  enable_telemetry   = var.enable_telemetry # see variables.tf
+  resource_group_id  = data.azurerm_resource_group.rg.id
+  custom_location_id = data.azapi_resource.customlocation.id
+  vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
+
 }
 ```
 
@@ -97,12 +113,6 @@ Description: The name of the custom location.
 
 Type: `string`
 
-### <a name="input_logical_network_name"></a> [logical\_network\_name](#input\_logical\_network\_name)
-
-Description: The name of the logical network
-
-Type: `string`
-
 ### <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name)
 
 Description: The resource group where the resources will be deployed.
@@ -131,7 +141,13 @@ No outputs.
 
 The following Modules are called:
 
-### <a name="module_test"></a> [test](#module\_test)
+### <a name="module_call1"></a> [call1](#module\_call1)
+
+Source: ../../
+
+Version:
+
+### <a name="module_call2"></a> [call2](#module\_call2)
 
 Source: ../../
 

--- a/examples/multi/README.md
+++ b/examples/multi/README.md
@@ -1,0 +1,144 @@
+<!-- BEGIN_TF_DOCS -->
+# Default example
+
+This deploys the module in its simplest form.
+
+```hcl
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 1.13"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.74"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+# This is required for resource modules
+data "azurerm_resource_group" "rg" {
+  name = var.resource_group_name
+}
+
+data "azapi_resource" "customlocation" {
+  type      = "Microsoft.ExtendedLocation/customLocations@2021-08-15"
+  name      = var.custom_location_name
+  parent_id = data.azurerm_resource_group.rg.id
+}
+
+# This is the module call
+# Do not specify location here due to the randomization above.
+# Leaving location as `null` will cause the module to use the resource group location
+# with a data source.
+module "test" {
+  source = "../../"
+  # source             = "Azure/avm-res-azurestackhci-logicalnetwork/azurerm"
+  # version = "~> 0.1.0"
+
+  location = data.azurerm_resource_group.rg.location
+  name     = var.logical_network_name
+
+  enable_telemetry   = var.enable_telemetry # see variables.tf
+  resource_group_id  = data.azurerm_resource_group.rg.id
+  custom_location_id = data.azapi_resource.customlocation.id
+  vm_switch_name     = "extSwitch"
+
+  ip_allocation_method = "Static"
+  starting_address     = "192.168.200.0"
+  ending_address       = "192.168.200.255"
+  default_gateway      = "192.168.200.1"
+
+  dns_servers    = ["192.168.200.222"]
+  address_prefix = "192.168.200.0/24"
+
+  logical_network_tags = {
+    environment = "development"
+  }
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 1.13)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azapi_resource.customlocation](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/resource) (data source)
+- [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+The following input variables are required:
+
+### <a name="input_custom_location_name"></a> [custom\_location\_name](#input\_custom\_location\_name)
+
+Description: The name of the custom location.
+
+Type: `string`
+
+### <a name="input_logical_network_name"></a> [logical\_network\_name](#input\_logical\_network\_name)
+
+Description: The name of the logical network
+
+Type: `string`
+
+### <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name)
+
+Description: The resource group where the resources will be deployed.
+
+Type: `string`
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
+
+Description: This variable controls whether or not telemetry is enabled for the module.  
+For more information see <https://aka.ms/avm/telemetryinfo>.  
+If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `true`
+
+## Outputs
+
+No outputs.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_test"></a> [test](#module\_test)
+
+Source: ../../
+
+Version:
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/multi/_footer.md
+++ b/examples/multi/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/multi/_header.md
+++ b/examples/multi/_header.md
@@ -1,3 +1,3 @@
 # Multiple Logical Network Provisioning example
 
-This deploys the module in its simplest form.
+This deploys multiple logical networks.

--- a/examples/multi/_header.md
+++ b/examples/multi/_header.md
@@ -1,0 +1,3 @@
+# Multiple Logical Network Provisioning example
+
+This deploys the module in its simplest form.

--- a/examples/multi/main.tf
+++ b/examples/multi/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 1.13"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.74"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+# This is required for resource modules
+data "azurerm_resource_group" "rg" {
+  name = var.resource_group_name
+}
+
+data "azapi_resource" "customlocation" {
+  type      = "Microsoft.ExtendedLocation/customLocations@2021-08-15"
+  name      = var.custom_location_name
+  parent_id = data.azurerm_resource_group.rg.id
+}
+
+# This is the module call
+# Do not specify location here due to the randomization above.
+# Leaving location as `null` will cause the module to use the resource group location
+# with a data source.
+module "call1" {
+  source = "../../"
+  # source             = "Azure/avm-res-azurestackhci-logicalnetwork/azurerm"
+  # version = "~> 0.1.0"
+
+  location = data.azurerm_resource_group.rg.location
+  name     = "lnetstatic"
+
+  enable_telemetry   = var.enable_telemetry # see variables.tf
+  resource_group_id  = data.azurerm_resource_group.rg.id
+  custom_location_id = data.azapi_resource.customlocation.id
+  vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
+
+  ip_allocation_method = "Static"
+  starting_address     = "192.168.200.0"
+  ending_address       = "192.168.200.255"
+  default_gateway      = "192.168.200.1"
+
+  dns_servers    = ["192.168.200.222"]
+  address_prefix = "192.168.200.0/24"
+
+  logical_network_tags = {
+    environment = "development"
+  }
+}
+
+
+module "call2" {
+  source = "../../"
+  # source             = "Azure/avm-res-azurestackhci-logicalnetwork/azurerm"
+  # version = "~> 0.1.0"
+
+  location = data.azurerm_resource_group.rg.location
+  name     = "lnetdynamic"
+
+  enable_telemetry   = var.enable_telemetry # see variables.tf
+  resource_group_id  = data.azurerm_resource_group.rg.id
+  custom_location_id = data.azapi_resource.customlocation.id
+  vm_switch_name     = "ConvergedSwitch(managementcomputestorage)"
+
+}

--- a/examples/multi/variables.tf
+++ b/examples/multi/variables.tf
@@ -1,0 +1,19 @@
+variable "custom_location_name" {
+  type        = string
+  description = "The name of the custom location."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The resource group where the resources will be deployed."
+}
+
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}


### PR DESCRIPTION
## Description

This example demonstrates how to deploy multiple logical networks using a single `main.tf` file. When you run `terraform apply`, it will deploy two logical networks:

1. lnetstatic - a static logical network
2. lnetdynamic - a dynamic logical network

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
